### PR TITLE
docs(s2-expert): update S2 expert skills with stickyHeader and interaction API

### DIFF
--- a/skills/antv-s2-expert/references/knowledge/05-events-interaction.md
+++ b/skills/antv-s2-expert/references/knowledge/05-events-interaction.md
@@ -174,9 +174,31 @@ The `s2.interaction` namespace provides methods for programmatic interaction:
 
 ```ts
 s2.interaction.selectAll();
-s2.interaction.selectCell(cell);
+s2.interaction.selectCell(cell, options?: ChangeCellOptions);
 s2.interaction.highlightCell(cell);
-s2.interaction.changeCell(cell);
+s2.interaction.changeCell(cell, options?: ChangeCellOptions);
+
+// Scrolling
+s2.interaction.scrollTo({ offsetX, offsetY });
+s2.interaction.scrollToNode(node, { animate: true });
+s2.interaction.scrollToCell(cell, { animate: true });
+s2.interaction.scrollToTop({ animate: true });
+```
+
+## Window-level Sticky Header
+
+If you want the table header to stick to the top of the viewport when the table content exceeds the screen height, use `interaction.stickyHeader`.
+
+```ts
+const s2Options = {
+  interaction: {
+    stickyHeader: {
+      offsetTop: 60, // e.g., offset for a top navigation bar
+      scrollContainer: window, // default
+      enableInteraction: true, // enable sorting/resizing while stuck
+    },
+  },
+};
 ```
 
 ## Custom Interactions

--- a/skills/antv-s2-expert/references/type/s2-options.md
+++ b/skills/antv-s2-expert/references/type/s2-options.md
@@ -175,6 +175,20 @@ Interaction configuration.
 | eventListenerOptions | `false` | | | Options for `addEventListener`, can control whether events trigger during bubble or capture phase |
 | selectedCellHighlight | `boolean \| { rowHeader?: boolean, colHeader?: boolean, currentRow?: boolean, currentCol?: boolean }` | | `false` | Row/column highlight linkage after selecting data cells |
 | overscrollBehavior | `"auto" \| "contain" \| "none" \| null` | | `auto` | Control behavior when scrolling to boundary, can disable browser default scroll behavior |
+| stickyHeader | `boolean \| StickyHeaderOptions` | | `false` | Enable window-level sticky header when table height exceeds viewport |
+
+### StickyHeaderOptions
+
+```ts
+export interface StickyHeaderOptions {
+  /** Offset from the top when stuck (e.g., for external fixed navigation bars) */
+  offsetTop?: number | (() => number);
+  /** External scroll container to bind to. Default is window */
+  scrollContainer?: HTMLElement | Window;
+  /** Whether to enable header interaction when stuck (sort/resize/expand) */
+  enableInteraction?: boolean;
+}
+```
 
 ### Copy
 


### PR DESCRIPTION
This PR updates the AntV S2 AI expert skills with the latest changes pulled from the main S2 repository's past 7 days.

## Updates
- **`s2-options.md`**: Added `stickyHeader` feature to `S2Options.interaction` to enable window-level sticky headers.
- **`05-events-interaction.md`**: Synced interaction methods with the new source code, adding scrolling interactions (`scrollTo`, `scrollToNode`, `scrollToCell`, etc.) and `ChangeCellOptions` for `selectCell` and `changeCell`.

---
*PR created automatically by Jules for task [9128264051973511716](https://jules.google.com/task/9128264051973511716) started by @Alexzjt*