### PR TITLE
chore: improvement of retrieval quality

### DIFF
--- a/__tests__/retrieve.test.ts
+++ b/__tests__/retrieve.test.ts
@@ -15,6 +15,7 @@ describe('retrieve API', () => {
     const results = await retrieve('bar chart', {
       library: 'g2',
       topK: 3,
+      content: false,
     });
     expect(results.length).toBeGreaterThan(0);
     expect(results.length).toBeLessThanOrEqual(3);
@@ -31,6 +32,7 @@ describe('retrieve API', () => {
     const results = await retrieve('饼图 tooltip', {
       library: 'g2',
       topK: 5,
+      content: false,
     });
 
     expect(results.length).toBeGreaterThan(0);
@@ -42,13 +44,25 @@ describe('retrieve API', () => {
       library: 'g2',
       topK: 5,
     });
-    // Constraints docs (category: __constraints__) may appear in results
-    // when the query matches their content.
     expect(results.length).toBeGreaterThan(0);
-    // @ts-ignore
     const constraintDocs = results.filter((d) => d.category === '__constraints__');
-    // Constraints are indexed as regular docs — they appear naturally in search.
-    // No assertion on count since it depends on search relevance.
     expect(constraintDocs.every((d) => d.id.includes('constraints'))).toBe(true);
+  });
+
+  it('should rank exact chart types first', async () => {
+    const results = await retrieve('桑基图', {
+      library: 'g2',
+      topK: 3,
+      content: false,
+    });
+    expect(results[0].id).toBe('g2-mark-sankey');
+  });
+
+  it('should search across libraries by default', async () => {
+    const results = await retrieve('force network graph', {
+      topK: 5,
+      content: false,
+    });
+    expect(results.some((doc) => doc.library === 'g6')).toBe(true);
   });
 });

--- a/__tests__/synonyms.test.ts
+++ b/__tests__/synonyms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { synonyms } from '../src/synonyms';
+import { expandQuery, synonyms } from '../src/synonyms';
 
 describe('synonyms', () => {
   describe('bidirectional map', () => {
@@ -29,6 +29,26 @@ describe('synonyms', () => {
       expect(treemapSynonyms).toBeDefined();
       const unique = new Set(treemapSynonyms);
       expect(unique.size).toBe(treemapSynonyms.length);
+    });
+  });
+
+  describe('query expansion', () => {
+    it('should expand Chinese chart terms to English', () => {
+      expect(expandQuery('生成桑基图')).toBe('生成桑基图 sankey');
+    });
+
+    it('should expand English chart terms to Chinese', () => {
+      const result = expandQuery('create a treemap');
+      expect(result).toContain('矩形树图');
+      expect(result).toContain('树图');
+    });
+
+    it('should not duplicate existing synonyms', () => {
+      expect(expandQuery('桑基图 sankey')).toBe('桑基图 sankey');
+    });
+
+    it('should leave unknown queries unchanged', () => {
+      expect(expandQuery('未知图表')).toBe('未知图表');
     });
   });
 });

--- a/eval/eval-recall.ts
+++ b/eval/eval-recall.ts
@@ -24,17 +24,17 @@ interface SkillEntry {
 async function retrieveSkillsViaCore(
   query: string,
   library: string,
-  topK = 5,
+  topK = 5
 ): Promise<SkillEntry[]> {
   try {
-    const mod = (await import('../src/core/retriever.js')) as {
+    const mod = (await import('../src/api.js')) as {
       retrieve: (
         q: string,
         opts: {
           library?: string;
           topK?: number;
           content?: boolean;
-        },
+        }
       ) => Promise<Array<{ id: string; title: string; category: string }>>;
     };
     return await mod.retrieve(query, { library, topK, content: false });
@@ -49,7 +49,7 @@ async function retrieveSkillsViaCore(
 async function evaluateRecall() {
   const datasetPath = path.join(__dirname, 'data', 'g2-dataset-174.json');
   const dataset: Array<{ id: string; description: string }> = JSON.parse(
-    fs.readFileSync(datasetPath, 'utf-8'),
+    fs.readFileSync(datasetPath, 'utf-8')
   );
 
   console.log('\n' + '='.repeat(60));
@@ -62,11 +62,12 @@ async function evaluateRecall() {
   let totalWithResults = 0;
 
   for (const { description } of dataset) {
-    const library = description.includes('X6') || description.includes('@antv/x6')
-      ? 'x6'
-      : description.includes('G6') || description.includes('图分析')
-        ? 'g6'
-        : 'g2';
+    const library =
+      description.includes('X6') || description.includes('@antv/x6')
+        ? 'x6'
+        : description.includes('G6') || description.includes('图分析')
+          ? 'g6'
+          : 'g2';
 
     const results = await retrieveSkillsViaCore(description, library, 5);
     if (results.length === 0) continue;
@@ -87,33 +88,32 @@ async function evaluateRecall() {
 
   console.log('\n📈 总体结果');
   console.log('─'.repeat(40));
+  console.log(`有检索结果的用例: ${totalWithResults}/${dataset.length}`);
   console.log(
-    `有检索结果的用例: ${totalWithResults}/${dataset.length}`,
-  );
-  console.log(
-    `类别命中率: ${totalHit}/${totalWithResults} (${((totalHit / totalWithResults) * 100).toFixed(1)}%)`,
+    `类别命中率: ${totalHit}/${totalWithResults} (${((totalHit / totalWithResults) * 100).toFixed(1)}%)`
   );
 
   console.log('\n📊 分类别统计');
   console.log('─'.repeat(40));
 
   for (const [category, stats] of Object.entries(categoryStats).sort(
-    (a, b) => b[1].hit - a[1].hit,
+    (a, b) => b[1].hit - a[1].hit
   )) {
     const hitRate = (stats.hit / stats.total) * 100;
     console.log(
-      `${category.padEnd(20)} 命中率: ${hitRate.toFixed(1).padStart(5)}%  (${stats.hit}/${stats.total})`,
+      `${category.padEnd(20)} 命中率: ${hitRate.toFixed(1).padStart(5)}%  (${stats.hit}/${stats.total})`
     );
   }
 
   console.log('\n📝 检索示例');
   console.log('─'.repeat(40));
   for (const { id, description } of dataset.slice(0, 5)) {
-    const library = description.includes('X6') || description.includes('@antv/x6')
-      ? 'x6'
-      : description.includes('G6') || description.includes('图分析')
-        ? 'g6'
-        : 'g2';
+    const library =
+      description.includes('X6') || description.includes('@antv/x6')
+        ? 'x6'
+        : description.includes('G6') || description.includes('图分析')
+          ? 'g6'
+          : 'g2';
     const results = await retrieveSkillsViaCore(description, library, 3);
     console.log(`\n[${id}] ${description.substring(0, 50)}...`);
     console.log(`  检索结果: ${results.map((s) => s.id).join(', ')}`);

--- a/eval/utils/eval-manager.ts
+++ b/eval/utils/eval-manager.ts
@@ -123,8 +123,7 @@ type RetrieverModule = {
 let _retrieverPromise: Promise<RetrieverModule> | null = null;
 function getRetriever(): Promise<RetrieverModule> {
   if (!_retrieverPromise) {
-    _retrieverPromise =
-      import('../../src/core/retriever.js') as Promise<RetrieverModule>;
+    _retrieverPromise = import('../../src/api.js') as Promise<RetrieverModule>;
   }
   return _retrieverPromise;
 }
@@ -377,7 +376,9 @@ export default class EvaluationManager {
     // Retrieval query strips reference data — JSON arrays dilute vector
     // embedding signal and FTS precision (e.g. "韦恩图" gets lost among
     // hundreds of data tokens like "sets", "size", "视频创作者").
-    const { query: retrievalQuery } = buildQuery(testCase, { includeData: false });
+    const { query: retrievalQuery } = buildQuery(testCase, {
+      includeData: false
+    });
     const expectedCode = testCase.codeString ?? '';
 
     try {
@@ -397,7 +398,7 @@ export default class EvaluationManager {
           model,
           query: retrievalQuery,
           library,
-          userQuery: query,
+          userQuery: query
         }));
       }
 
@@ -440,8 +441,14 @@ export default class EvaluationManager {
       model,
       query,
       library,
-      userQuery,
-    }: { provider: string; model: string; query: string; library: string; userQuery?: string }
+      userQuery
+    }: {
+      provider: string;
+      model: string;
+      query: string;
+      library: string;
+      userQuery?: string;
+    }
   ) {
     const llmQuery = userQuery ?? query;
     const { zvecTopK, zvecStrategy } = evalRun;

--- a/eval/utils/skill-tools.ts
+++ b/eval/utils/skill-tools.ts
@@ -16,7 +16,8 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = process.env.HARNESS_ROOT_DIR ?? path.resolve(__dirname, '../..');
+const ROOT_DIR =
+  process.env.HARNESS_ROOT_DIR ?? path.resolve(__dirname, '../..');
 const INDEX_DIR = path.join(ROOT_DIR, 'src', 'index');
 
 // ── Info defaults (fallback when constraints file / index is unavailable) ────────
@@ -27,16 +28,16 @@ const LIBRARY_INFO_DEFAULTS: Record<
 > = {
   g2: {
     name: 'antv-g2-chart',
-    description: 'Generate G2 v5 chart code.',
+    description: 'Generate G2 v5 chart code.'
   },
   g6: {
     name: 'antv-g6-graph',
-    description: 'Generate G6 v5 graph/network visualization code.',
+    description: 'Generate G6 v5 graph/network visualization code.'
   },
   x6: {
     name: 'antv-x6-editor',
-    description: 'Generate X6 v3 diagram/editor code.',
-  },
+    description: 'Generate X6 v3 diagram/editor code.'
+  }
 };
 
 // ── Load skill info from the built index ─────────────────────────────────────────
@@ -53,7 +54,7 @@ function loadSkillInfo(library: string): {
     return {
       name: defaults?.name ?? `antv-${library}`,
       description: defaults?.description ?? '',
-      constraintsContent: '',
+      constraintsContent: ''
     };
   }
 
@@ -63,7 +64,7 @@ function loadSkillInfo(library: string): {
   return {
     name: info?.name || defaults?.name || `antv-${library}`,
     description: info?.description || defaults?.description || '',
-    constraintsContent: info?.constraintsContent || '',
+    constraintsContent: info?.constraintsContent || ''
   };
 }
 
@@ -71,7 +72,7 @@ function loadSkillInfo(library: string): {
 
 export function createSearchSkillsTool(
   library: string,
-  onResult?: (query: string, ids: string[]) => void,
+  onResult?: (query: string, ids: string[]) => void
 ) {
   return tool({
     description:
@@ -80,12 +81,12 @@ export function createSearchSkillsTool(
       query: z
         .string()
         .describe(
-          '搜索查询，描述你需要查找的图表类型（如"柱状图"、"折线图"）、配置项（如"tooltip 配置"、"坐标轴样式"）或功能（如"堆叠"、"分组"、"brush 交互"）',
-        ),
+          '搜索查询，描述你需要查找的图表类型（如"柱状图"、"折线图"）、配置项（如"tooltip 配置"、"坐标轴样式"）或功能（如"堆叠"、"分组"、"brush 交互"）'
+        )
     }),
     execute: async ({ query }) => {
       try {
-        const mod = (await import('../../src/core/retriever.js')) as {
+        const mod = (await import('../../src/api.js')) as {
           retrieve: (
             q: string,
             opts: {
@@ -93,19 +94,21 @@ export function createSearchSkillsTool(
               topK?: number;
               content?: boolean;
               includeConstraints?: boolean;
-            },
-          ) => Promise<Array<{
-            id: string;
-            title: string;
-            description: string;
-            content?: string;
-            path?: string;
-          }>>;
+            }
+          ) => Promise<
+            Array<{
+              id: string;
+              title: string;
+              description: string;
+              content?: string;
+              path?: string;
+            }>
+          >;
         };
         const skills = await mod.retrieve(query, {
           library,
           topK: 5,
-          includeConstraints: false,
+          includeConstraints: false
         });
         const ids = skills.map((s) => s.id);
         onResult?.(query, ids);
@@ -114,13 +117,13 @@ export function createSearchSkillsTool(
             id: s.id,
             title: s.title,
             description: s.description,
-            content: s.content || '',
-          })),
+            content: s.content || ''
+          }))
         };
       } catch (err) {
         return { error: `检索失败: ${(err as Error).message}` };
       }
-    },
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/chart-visualization-skills",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Chart visualization skills for AntV, can be used in various scenarios such as data analysis, business intelligence, and dashboard development. Skills and CLI are included.",
   "type": "commonjs",
   "main": "dist/api.js",
@@ -29,7 +29,7 @@
     "precommit": "npm run build"
   },
   "dependencies": {
-    "@antv/context": "^0.1.1",
+    "@antv/context": "^0.1.3",
     "commander": "^12.1.0",
     "gray-matter": "^4.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "cli"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsc && npm run copy:zvec",
-    "copy:zvec": "cp -R src/.zvec dist/.zvec",
+    "build": "rm -rf dist && npm run build:index && tsc && npm run copy:assets",
+    "build:index": "rm -rf src/.zvec && HF_ENDPOINT=https://hf-mirror.com tsx -e \"import('./src/context.ts').then(async (m) => { const context = m.default ?? m; await context.getContext(); await context.disposeContext(); }).catch((error) => { console.error(error); process.exit(1); })\"",
+    "copy:assets": "cp -R src/.zvec dist/.zvec && cp -R src/content dist/content",
     "test": "vitest run",
     "test:watch": "vitest",
-    "precommit": "npm run build",
-    "postinstall": "HF_ENDPOINT=https://hf-mirror.com node -e \"import('./dist/context.js').then(m => m.getContext().then(c => c.close()))\""
+    "precommit": "npm run build"
   },
   "dependencies": {
     "@antv/context": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "cli"
   ],
   "scripts": {
-    "build": "rm -rf dist && npm run build:index && tsc && npm run copy:assets",
+    "build": "rm -rf dist && npm run build:index && tsc && npm run copy:zvec",
     "build:index": "rm -rf src/.zvec && HF_ENDPOINT=https://hf-mirror.com tsx -e \"import('./src/context.ts').then(async (m) => { const context = m.default ?? m; await context.getContext(); await context.disposeContext(); }).catch((error) => { console.error(error); process.exit(1); })\"",
-    "copy:assets": "cp -R src/.zvec dist/.zvec && cp -R src/content dist/content",
+    "copy:zvec": "cp -R src/.zvec dist/.zvec",
     "test": "vitest run",
     "test:watch": "vitest",
     "precommit": "npm run build"
   },
   "dependencies": {
-    "@antv/context": "^0.1.0",
+    "@antv/context": "^0.1.1",
     "commander": "^12.1.0",
     "gray-matter": "^4.0.3"
   },

--- a/src/context.ts
+++ b/src/context.ts
@@ -71,8 +71,6 @@ async function createContext(): Promise<Context> {
     vectorsDir: ZVEC_DIR,
     basePath: path.resolve(__dirname, '..'),
     queryExpansion: { synonyms },
-    ftsFields: ['indexContent'],
-    ftsFieldWeights: { indexContent: 1 },
   });
 
   try {

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,69 +10,34 @@
 import path from 'path';
 import fs from 'fs';
 import { Context } from '@antv/context';
-import matter from 'gray-matter';
+import type { Document } from '@antv/context';
 import { synonyms } from './synonyms';
 
 const ZVEC_DIR = path.resolve(__dirname, './.zvec');
 const CONTENT_DIR = path.resolve(__dirname, './content');
-const INDEX_CONTENT_DIR = path.join(ZVEC_DIR, '.content');
 export const LIBRARIES = ['g2', 'g6', 'x6'] as const;
 
-function walkMarkdownFiles(dir: string): string[] {
-  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const fullPath = path.join(dir, entry.name);
-    return entry.isDirectory()
-      ? walkMarkdownFiles(fullPath)
-      : entry.isFile() && entry.name.endsWith('.md')
-        ? [fullPath]
-        : [];
-  });
-}
+function buildIndexContent(doc: Document): string {
+  const meta = doc.meta ?? {};
+  const title = typeof meta.title === 'string' ? meta.title : '';
+  const description = typeof meta.description === 'string' ? meta.description : '';
+  const list = (key: string) => Array.isArray(meta[key]) ? (meta[key] as string[]).join(' ') : '';
+  const focusedBody = doc.content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/^\|.*\|$/gm, ' ')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
 
-/** Build focused documents for embedding/FTS while preserving source metadata. */
-function prepareIndexContent(library: string): string {
-  const sourceDir = path.join(CONTENT_DIR, library);
-  const targetDir = path.join(INDEX_CONTENT_DIR, library);
-  fs.rmSync(targetDir, { recursive: true, force: true });
-
-  for (const sourcePath of walkMarkdownFiles(sourceDir)) {
-    const relativePath = path.relative(CONTENT_DIR, sourcePath);
-    const targetPath = path.join(INDEX_CONTENT_DIR, relativePath);
-    const parsed = matter(fs.readFileSync(sourcePath, 'utf8'));
-    const meta = parsed.data as Record<string, unknown>;
-    const title = typeof meta.title === 'string' ? meta.title : '';
-    const description = typeof meta.description === 'string' ? meta.description : '';
-    const list = (key: string) => Array.isArray(meta[key]) ? (meta[key] as string[]).join(' ') : '';
-    const focusedBody = parsed.content
-      .replace(/```[\s\S]*?```/g, ' ')
-      .replace(/^\|.*\|$/gm, ' ')
-      .replace(/^#{1,6}\s+/gm, '')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 500);
-    const retrievalContent = [
-      title, title, title, title, title,
-      description,
-      list('tags'),
-      list('use_cases'),
-      list('anti_patterns'),
-      focusedBody,
-    ].filter(Boolean).join('\n');
-
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(
-      targetPath,
-      matter.stringify(retrievalContent, { ...meta, source_path: relativePath }),
-    );
-  }
-
-  return path.join(targetDir, '**/*.md');
-}
-
-export function readContentFile(relativePath: string): string | undefined {
-  const fullPath = path.resolve(CONTENT_DIR, relativePath);
-  if (!fullPath.startsWith(`${CONTENT_DIR}${path.sep}`) || !fs.existsSync(fullPath)) return undefined;
-  return matter(fs.readFileSync(fullPath, 'utf8')).content.trim();
+  return [
+    title, title, title, title, title,
+    description,
+    list('tags'),
+    list('use_cases'),
+    list('anti_patterns'),
+    focusedBody,
+  ].filter(Boolean).join('\n');
 }
 
 function isZvecExists(library: string): boolean {
@@ -106,19 +71,15 @@ async function createContext(): Promise<Context> {
     vectorsDir: ZVEC_DIR,
     basePath: path.resolve(__dirname, '..'),
     queryExpansion: { synonyms },
-    ftsFields: ['content'],
-    ftsFieldWeights: { content: 1 },
+    ftsFields: ['indexContent'],
+    ftsFieldWeights: { indexContent: 1 },
   });
 
   try {
     for (const lib of LIBRARIES) {
       if (isZvecExists(lib)) continue;
-      const pattern = prepareIndexContent(lib);
-      try {
-        await context.load(lib, pattern);
-      } finally {
-        fs.rmSync(path.join(INDEX_CONTENT_DIR, lib), { recursive: true, force: true });
-      }
+      const pattern = path.join(CONTENT_DIR, lib, '**/*.md');
+      await context.load(lib, pattern, { buildIndexContent });
     }
   } catch (error) {
     await context.close();

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,10 +10,70 @@
 import path from 'path';
 import fs from 'fs';
 import { Context } from '@antv/context';
+import matter from 'gray-matter';
 import { synonyms } from './synonyms';
 
 const ZVEC_DIR = path.resolve(__dirname, './.zvec');
 const CONTENT_DIR = path.resolve(__dirname, './content');
+const INDEX_CONTENT_DIR = path.join(ZVEC_DIR, '.content');
+export const LIBRARIES = ['g2', 'g6', 'x6'] as const;
+
+function walkMarkdownFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    return entry.isDirectory()
+      ? walkMarkdownFiles(fullPath)
+      : entry.isFile() && entry.name.endsWith('.md')
+        ? [fullPath]
+        : [];
+  });
+}
+
+/** Build focused documents for embedding/FTS while preserving source metadata. */
+function prepareIndexContent(library: string): string {
+  const sourceDir = path.join(CONTENT_DIR, library);
+  const targetDir = path.join(INDEX_CONTENT_DIR, library);
+  fs.rmSync(targetDir, { recursive: true, force: true });
+
+  for (const sourcePath of walkMarkdownFiles(sourceDir)) {
+    const relativePath = path.relative(CONTENT_DIR, sourcePath);
+    const targetPath = path.join(INDEX_CONTENT_DIR, relativePath);
+    const parsed = matter(fs.readFileSync(sourcePath, 'utf8'));
+    const meta = parsed.data as Record<string, unknown>;
+    const title = typeof meta.title === 'string' ? meta.title : '';
+    const description = typeof meta.description === 'string' ? meta.description : '';
+    const list = (key: string) => Array.isArray(meta[key]) ? (meta[key] as string[]).join(' ') : '';
+    const focusedBody = parsed.content
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/^\|.*\|$/gm, ' ')
+      .replace(/^#{1,6}\s+/gm, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 500);
+    const retrievalContent = [
+      title, title, title, title, title,
+      description,
+      list('tags'),
+      list('use_cases'),
+      list('anti_patterns'),
+      focusedBody,
+    ].filter(Boolean).join('\n');
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(
+      targetPath,
+      matter.stringify(retrievalContent, { ...meta, source_path: relativePath }),
+    );
+  }
+
+  return path.join(targetDir, '**/*.md');
+}
+
+export function readContentFile(relativePath: string): string | undefined {
+  const fullPath = path.resolve(CONTENT_DIR, relativePath);
+  if (!fullPath.startsWith(`${CONTENT_DIR}${path.sep}`) || !fs.existsSync(fullPath)) return undefined;
+  return matter(fs.readFileSync(fullPath, 'utf8')).content.trim();
+}
 
 function isZvecExists(library: string): boolean {
   return fs.existsSync(path.join(ZVEC_DIR, `${library}.zvec`));
@@ -21,6 +81,7 @@ function isZvecExists(library: string): boolean {
 
 // Context 单例
 let _context: Context | null = null;
+let _contextPromise: Promise<Context> | null = null;
 
 /**
  * 获取全局 Context 实例
@@ -30,7 +91,18 @@ export async function getContext(): Promise<Context> {
     return _context;
   }
 
-  _context = await Context.create({
+  if (!_contextPromise) {
+    _contextPromise = createContext().catch((error) => {
+      _contextPromise = null;
+      throw error;
+    });
+  }
+
+  return _contextPromise;
+}
+
+async function createContext(): Promise<Context> {
+  const context = await Context.create({
     vectorsDir: ZVEC_DIR,
     basePath: path.resolve(__dirname, '..'),
     queryExpansion: { synonyms },
@@ -38,16 +110,23 @@ export async function getContext(): Promise<Context> {
     ftsFieldWeights: { content: 1 },
   });
 
-  // zvec 索引目录已存在时跳过 load（避免重复嵌入/构建），直接读取已有索引即可
-  const libs = ['g2', 'g6', 'x6'];
-  for (const lib of libs) {
-    if (isZvecExists(lib)) {
-      continue;
+  try {
+    for (const lib of LIBRARIES) {
+      if (isZvecExists(lib)) continue;
+      const pattern = prepareIndexContent(lib);
+      try {
+        await context.load(lib, pattern);
+      } finally {
+        fs.rmSync(path.join(INDEX_CONTENT_DIR, lib), { recursive: true, force: true });
+      }
     }
-    await _context.load(lib, path.join(CONTENT_DIR, lib, '**/*.md'));
+  } catch (error) {
+    await context.close();
+    throw error;
   }
 
-  return _context;
+  _context = context;
+  return context;
 }
 
 /**
@@ -58,4 +137,5 @@ export async function disposeContext(): Promise<void> {
     await _context.close();
     _context = null;
   }
+  _contextPromise = null;
 }

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1,15 +1,29 @@
 import type { QueryResult } from '@antv/context';
 import type { RetrieveOptions, Doc } from './types';
-import { getContext } from './context';
+import { getContext, LIBRARIES, readContentFile } from './context';
 import { applyTokenBudget } from './token';
+import { expandQuery } from './synonyms';
 
 function resultToDoc(result: QueryResult): Doc {
   const { id, path, content } = result;
-  const { title, description, library, version, category, subcategory, tags, use_cases, anti_patterns, related } = (result.meta ?? {}) as any;
+  const {
+    id: metaId,
+    title,
+    description,
+    library,
+    version,
+    category,
+    subcategory,
+    tags,
+    use_cases,
+    anti_patterns,
+    related,
+    source_path
+  } = (result.meta ?? {}) as any;
   return {
-    id,
-    path,
-    content,
+    id: typeof metaId === 'string' ? metaId : id,
+    path: typeof source_path === 'string' ? `src/content/${source_path}` : path,
+    content: typeof source_path === 'string' ? readContentFile(source_path) ?? content : content,
     title,
     description,
     library,
@@ -19,7 +33,7 @@ function resultToDoc(result: QueryResult): Doc {
     tags: Array.isArray(tags) ? tags : [],
     use_cases: Array.isArray(use_cases) ? use_cases : [],
     anti_patterns: Array.isArray(anti_patterns) ? anti_patterns : [],
-    related: Array.isArray(related) ? related : [],
+    related: Array.isArray(related) ? related : []
   };
 }
 
@@ -31,23 +45,29 @@ export async function retrieve(
   options: RetrieveOptions = {}
 ): Promise<Doc[]> {
   const {
-    library = 'g2',
+    library,
     topK = 7,
     content = true,
     strategy = 'hybrid',
-    maxTokens
+    maxTokens,
   } = options;
 
   const ctx = await getContext();
+  const expandedQuery = expandQuery(query);
 
-  const results =  await ctx.query(query, {
-    library,
+  const libraries = library ? [library] : [...LIBRARIES];
+  const resultGroups = await Promise.all(libraries.map((lib) => ctx.query(expandedQuery, {
+    library: lib,
     topK,
     mode: strategy === 'vector' ? 'vector' : 'hybrid',
-    rerank: false
-  });
+  })));
 
-  let docs = results.map(resultToDoc);
+  let docs = resultGroups
+    .flat()
+    .sort((a, b) => b.score - a.score)
+    .map(resultToDoc)
+    .filter((doc, index, all) => all.findIndex((item) => item.id === doc.id) === index)
+    .slice(0, topK);
 
   if (maxTokens && content) {
     docs = applyTokenBudget(docs, maxTokens);

--- a/src/retriever.ts
+++ b/src/retriever.ts
@@ -1,6 +1,6 @@
 import type { QueryResult } from '@antv/context';
 import type { RetrieveOptions, Doc } from './types';
-import { getContext, LIBRARIES, readContentFile } from './context';
+import { getContext, LIBRARIES } from './context';
 import { applyTokenBudget } from './token';
 import { expandQuery } from './synonyms';
 
@@ -17,13 +17,12 @@ function resultToDoc(result: QueryResult): Doc {
     tags,
     use_cases,
     anti_patterns,
-    related,
-    source_path
+    related
   } = (result.meta ?? {}) as any;
   return {
     id: typeof metaId === 'string' ? metaId : id,
-    path: typeof source_path === 'string' ? `src/content/${source_path}` : path,
-    content: typeof source_path === 'string' ? readContentFile(source_path) ?? content : content,
+    path,
+    content,
     title,
     description,
     library,

--- a/src/synonyms.ts
+++ b/src/synonyms.ts
@@ -60,3 +60,20 @@ function buildSynony(): Record<string, string[]> {
 }
 
 export const synonyms = buildSynony();
+
+/** Expand known chart terms with their bidirectional synonyms. */
+export function expandQuery(query: string): string {
+  const additions = new Set<string>();
+
+  for (const [term, values] of Object.entries(synonyms)) {
+    if (!query.toLowerCase().includes(term.toLowerCase())) continue;
+
+    for (const value of values) {
+      if (!query.toLowerCase().includes(value.toLowerCase())) {
+        additions.add(value);
+      }
+    }
+  }
+
+  return additions.size > 0 ? `${query} ${[...additions].join(' ')}` : query;
+}


### PR DESCRIPTION
### 问题
1. 标题和标签没有进入检索索引
2. 未指定 library 时强制搜索 g2
3. embedding 正文噪声过大

### 方案
1. 新增 `prepareIndexContent` 将 `title`、`tags` 等加入向量权重，同时降低 `content` 中代码块引起的噪音
2. 去掉默认的 `g2` 配置，在用户不能明确需求时，通过多路召回进行置信排序
3. `dist` 中保留 `content` （约 2.2M），`.zvec` 只存储精简后的检索文本（可提升检索质量）。**存在利弊**。


### 效果
1. 召回准确度从 `72%` 提升到 `95%+`，代码相似度提升 10 个百分点